### PR TITLE
fixed "underscores make text cursief bug"

### DIFF
--- a/mee6/plugins/streamers.py
+++ b/mee6/plugins/streamers.py
@@ -202,7 +202,7 @@ class Streamers(Plugin):
         embed.add_field('Viewers', stream['viewers'], True)
 
         message = guild.config.announcement_message
-        message = message.replace('{streamer}', embed.author_name)
+        message = message.replace('{streamer}', embed.author_name.replace('_', '\_'))
         message = message.replace('{link}', embed.url)
 
         self.log('[Twitch] Announcing {} to {}'.format(embed.author_name, guild.id))


### PR DESCRIPTION
underscores in links are not "starting" a cursief part, but they can and a cursief part.
by doing the replace _ => \_ on the name itself it won't break underlined text in the custom streamer announcement messages